### PR TITLE
Installer Fix - Exception ->" Argument #1 ($command) must be of type array, string given"

### DIFF
--- a/src/Commands/InstallMenuBuilder.php
+++ b/src/Commands/InstallMenuBuilder.php
@@ -27,10 +27,10 @@ class InstallMenuBuilder extends Command
      *
      * @var string
      */
-    protected $seedersPath = __DIR__.'/../../database/seeds/';
+    protected $seedersPath = __DIR__ . '/../../database/seeds/';
 
     /**
-     * Get Option.
+     * Get Option
      *
      * @return array
      */
@@ -48,10 +48,10 @@ class InstallMenuBuilder extends Command
      */
     protected function findComposer()
     {
-        if (file_exists(getcwd().'/composer.phar')) {
-            return '"'.PHP_BINARY.'" '.getcwd().'/composer.phar';
+        if (file_exists(getcwd() . '/composer.phar')) {
+            /* return '"' . PHP_BINARY . '" ' . getcwd() . '/composer.phar'; // Leading quotes causing duplicate returns (origin) */
+            return PHP_BINARY . '" ' . getcwd() . '/composer.phar'; /* Removed leading quotation marks */
         }
-
         return 'composer';
     }
 
@@ -74,7 +74,8 @@ class InstallMenuBuilder extends Command
 
         $this->info('Dumping the autoloaded files and reloading all new files');
         $composer = $this->findComposer();
-        $process = Process::fromShellCommandline($composer.' dump-autoload');
+        /* $process  = new Process($composer . ' dump-autoload'); // Process waits array, as can be seen during the release of the exception: "Symfony\Component\Process\Process::__construct(): Argument #1 ($command) must be of type array, string given" */
+        $process  = new Process([$composer . ' dump-autoload']); /* Command passed as array */
         $process->setTimeout(null); // Setting timeout to null to prevent installation from stopping at a certain point in time
         $process->setWorkingDirectory(base_path())->run();
 
@@ -84,13 +85,13 @@ class InstallMenuBuilder extends Command
         if (false === strpos($routes_contents, 'MenuBuilder::routes();')) {
             $filesystem->append(
                 base_path('routes/web.php'),
-                "\n\nMenuBuilder::routes();\n"
+                "\n\nRoute::group(['prefix' => config('menu.prefix')], function () {\n    MenuBuilder::routes();\n});\n"
             );
         }
 
         // Seeding Dummy Data
         $class = 'MenuDatabaseSeeder';
-        $file = $this->seedersPath.$class.'.php';
+        $file  = $this->seedersPath . $class . '.php';
 
         if (file_exists($file) && !class_exists($class)) {
             require_once $file;

--- a/src/Commands/InstallMenuBuilder_v2.5.php
+++ b/src/Commands/InstallMenuBuilder_v2.5.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace CodexShaper\Menu\Commands;
+
+use CodexShaper\Menu\MenuServiceProvider;
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Process\Process;
+
+class InstallMenuBuilder extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'menu:install';
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Install the Laravel Menu Builder';
+    /**
+     * The database Seeder Path.
+     *
+     * @var string
+     */
+    protected $seedersPath = __DIR__ . '/../../database/seeds/';
+
+    /**
+     * Get Option
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production', null],
+        ];
+    }
+
+    /**
+     * Get the composer command for the environment.
+     *
+     * @return string
+     */
+    protected function findComposer()
+    {
+        if (file_exists(getcwd() . '/composer.phar')) {
+            // return '"' . PHP_BINARY . '" ' . getcwd() . '/composer.phar'; // Leading quotes causing duplicate returns (origin)
+            return PHP_BINARY . '" ' . getcwd() . '/composer.phar'; // Removed leading quotation marks
+        }
+        return 'composer';
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @param \Illuminate\Filesystem\Filesystem $filesystem
+     *
+     * @return void
+     */
+    public function handle(Filesystem $filesystem)
+    {
+        $this->info('Publishing the MenuBuilder assets, database, and config files');
+        // Publish only relevant resources on install
+        $tags = ['menu.seeds', 'menu.config'];
+        $this->call('vendor:publish', ['--provider' => MenuServiceProvider::class, '--tag' => $tags]);
+
+        $this->info('Migrating the database tables into your application');
+        $this->call('migrate', ['--force' => $this->option('force')]);
+
+        $this->info('Dumping the autoloaded files and reloading all new files');
+        $composer = $this->findComposer();
+        /* $process  = new Process($composer . ' dump-autoload'); // Process waits array, as can be seen during the release of the exception: "Symfony\Component\Process\Process::__construct(): Argument #1 ($command) must be of type array, string given" */
+        $process  = new Process([$composer . ' dump-autoload']); /* Comando passado como array */
+        $process->setTimeout(null); // Setting timeout to null to prevent installation from stopping at a certain point in time
+        $process->setWorkingDirectory(base_path())->run();
+
+        // Load Permission routes into application's 'routes/web.php'
+        $this->info('Adding Permission routes to routes/web.php');
+        $routes_contents = $filesystem->get(base_path('routes/web.php'));
+        if (false === strpos($routes_contents, 'MenuBuilder::routes();')) {
+            $filesystem->append(
+                base_path('routes/web.php'),
+                "\n\nRoute::group(['prefix' => config('menu.prefix')], function () {\n    MenuBuilder::routes();\n});\n"
+            );
+        }
+
+        // Seeding Dummy Data
+        $class = 'MenuDatabaseSeeder';
+        $file  = $this->seedersPath . $class . '.php';
+
+        if (file_exists($file) && !class_exists($class)) {
+            require_once $file;
+        }
+        with(new $class())->run();
+
+        $this->info('Seeding Completed');
+    }
+}


### PR DESCRIPTION
Error handling during execution of "php artisan menu:install" : "Symfony\Component\Process\Process::__construct(): Argument #1 ($command) must be of type array, string given, called in /path/of/the/application/vendor/codexshaper/laravel-menu
-builder/src/Commands/InstallMenuBuilder.php on line 75.

`-> % php artisan menu:install
Publishing the MenuBuilder assets, database, and config files
Copied Directory [\vendor\codexshaper\laravel-menu-builder\database\seeds] To [\database\seeds]
Publishing complete.
Migrating the database tables into your application
Migrating: 2019_08_22_221932_create_menus_table
Migrated:  2019_08_22_221932_create_menus_table (641.77ms)
Migrating: 2019_08_27_165403_create_menu_items_table
Migrated:  2019_08_27_165403_create_menu_items_table (740.65ms)
Migrating: 2019_08_27_165403_create_menu_settings_table
Migrated:  2019_08_27_165403_create_menu_settings_table (1,351.78ms)
Dumping the autoloaded files and reloading all new files

   TypeError

  Symfony\Component\Process\Process::__construct(): Argument #1 ($command) must be of type array, string given, called in \path\of\the\application\vendor\codexshaper\laravel-menu
-builder\src\Commands\InstallMenuBuilder.php on line 75

  at \path\of\the\application\vendor\symfony\process\Process.php:141
    137▕      * @param int|float|null $timeout The timeout in seconds or null to disable
    138▕      *
    139▕      * @throws LogicException When proc_open is not installed
    140▕      */
  ➜ 141▕     public function __construct(array $command, string $cwd = null, array $env = null, $input = null, ?float $timeout = 60)
    142▕     {
    143▕         if (!\function_exists('proc_open')) {
    144▕             throw new LogicException('The Process class relies on proc_open, which is not available on your PHP installation.');
    145▕         }

  1   \path\of\the\application\vendor\codexshaper\laravel-menu-builder\src\Commands\InstallMenuBuilder.php:75
      Symfony\Component\Process\Process::__construct(""D:\php8_0_3\php.exe" J:\prj_developer\www\amago_sgi/composer.phar dump-autoload")

  2   \path\of\the\application\vendor\laravel\framework\src\Illuminate\Container\BoundMethod.php:36
      CodexShaper\Menu\Commands\InstallMenuBuilder::handle(Object(Illuminate\Filesystem\Filesystem))
`